### PR TITLE
[FCM-nil] Disable unused FHIR model requirements

### DIFF
--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fhir_client/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'ruby_fhir_client'
+  spec.name          = 'fhir_client'
   spec.version       = FHIR::Client::VERSION
   spec.authors       = ['Andre Quina', 'Jason Walonoski', 'Robert Scanlon', 'Reece Adamson']
   spec.email         = ['jwalonoski@mitre.org']
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.3'
 
-  spec.add_dependency 'ruby_fhir_models'
+  spec.add_dependency 'fhir_models', '>= 4.2.1'
   # spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
   # spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.10.4'

--- a/lib/fhir_client.rb
+++ b/lib/fhir_client.rb
@@ -1,6 +1,8 @@
 require 'fhir_models'
-require 'fhir_dstu2_models'
-require 'fhir_stu3_models'
+# disable requiring the following models as they are not used in FCM's FHIR implementation
+# and require extra memory that can cause problems on staging environments
+# require 'fhir_dstu2_models'
+# require 'fhir_stu3_models'
 require 'active_support/all'
 
 # Default to INFO level logging for all FHIR namespaced logging. Since there is

--- a/ruby_fhir_client.gemspec
+++ b/ruby_fhir_client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.3'
 
-  spec.add_dependency 'ruby_fhir_models', git: 'https://github.com/footholdtech/ruby_fhir_models.git', branch: 'fcm-nil-disable-unused-requirements'
+  spec.add_dependency 'ruby_fhir_models'
   # spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
   # spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.10.4'

--- a/ruby_fhir_client.gemspec
+++ b/ruby_fhir_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fhir_client/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'fhir_client'
+  spec.name          = 'ruby_fhir_client'
   spec.version       = FHIR::Client::VERSION
   spec.authors       = ['Andre Quina', 'Jason Walonoski', 'Robert Scanlon', 'Reece Adamson']
   spec.email         = ['jwalonoski@mitre.org']
@@ -23,9 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'addressable', '>= 2.3'
-  spec.add_dependency 'fhir_models', '>= 4.2.1'
-  spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
-  spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
+
+  spec.add_dependency 'ruby_fhir_models', git: 'https://github.com/footholdtech/ruby_fhir_models.git', branch: 'fcm-nil-disable-unused-requirements'
+  # spec.add_dependency 'fhir_stu3_models', '>= 3.1.1'
+  # spec.add_dependency 'fhir_dstu2_models', '>= 1.1.1'
   spec.add_dependency 'nokogiri', '>= 1.10.4'
   spec.add_dependency 'oauth2', '~> 1.1'
   spec.add_dependency 'rack', '>= 1.5'


### PR DESCRIPTION
This is a "quick and dirty" fix to address some of the memory consumption issues that were being encountered on non-production environments when incorporating this library into the RMA code. 

In short, we're only using the R4 FHIR models in our use case, so all requiring the STU3 and DSTU2 models does for us is use additional resources. 

Being a "quick and dirty" fix, however, means that this breaks the existing tests for this gem. It'd be relatively straightforward to comment out/delete all of the references to these models that exist in the code/tests to get tests to pass, but I'm not sure how concerned we are with that. I'll consider the reviewer's opinion here on what's best. 